### PR TITLE
Remove 'text' from required params from sendExternal

### DIFF
--- a/app/Lib/Tools/SendEmail.php
+++ b/app/Lib/Tools/SendEmail.php
@@ -279,7 +279,7 @@ class SendEmail
      */
     public function sendExternal(array $params)
     {
-        foreach (array('body', 'reply-to', 'to', 'subject', 'text') as $requiredParam) {
+        foreach (array('body', 'reply-to', 'to', 'subject') as $requiredParam) {
             if (!isset($params[$requiredParam])) {
                 throw new InvalidArgumentException("Param '$requiredParam' is required, but not provided.");
             }


### PR DESCRIPTION
Bug fix, 
In HEAD, requesting access to a community fails, because of an error.
Tracking the bug down to this file, where
there is no such field named 'text' in params. 
It's probably a typo from reading line 309 too fast

MISP v2.4.133 (12c373511ed00bad8ab846e4d317411991a1d353) 

#### What does it do?

This fixes a bug where email to external (Community access request) are not working because the send email function is not working. see stack trace below.

the 'text' parameter is not a parameter in the sendemail functions. Probably a typo from reading the "format = 'text' " line L309

#### Questions

- [ ] Does it require a DB change? 
NO
- [ ] Are you using it in production?
YES
- [ ] Does it require a change in the API (PyMISP for example)?
NO

### original error

2020-10-29 15:10:08 Error: [InvalidArgumentException] Param 'text' is required, but not provided.
Request URL: /communities/requestAccess/3ab3a65a-0171-401a-9895-8d42bc7bed7c
Stack Trace:
#0 /var/www/MISP/app/Model/User.php(754): SendEmail->sendExternal()
#1 /var/www/MISP/app/Controller/CommunitiesController.php(149): User->sendEmailExternal()
#2 [internal function]: CommunitiesController->requestAccess()
#3 /var/www/MISP/app/Lib/cakephp/lib/Cake/Controller/Controller.php(499): ReflectionMethod->invokeArgs()
#4 /var/www/MISP/app/Lib/cakephp/lib/Cake/Routing/Dispatcher.php(193): Controller->invokeAction()
#5 /var/www/MISP/app/Lib/cakephp/lib/Cake/Routing/Dispatcher.php(167): Dispatcher->_invoke()
#6 /var/www/MISP/app/webroot/index.php(92): Dispatcher->dispatch()

